### PR TITLE
Init the exports member to empty object

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var Module = function(id, parent){
 	this._require = _require;
 	this.filename = undefined;
 	this.__dir = undefined;
+	this.exports = {} // otherwise the exports is undefined ...
 }
 
 


### PR DESCRIPTION
Init the exports member to empty object ,
Otherwise the exports is undefined on sub folder that uses the require.
